### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/src/main/html/javascript/gmaps.js
+++ b/src/main/html/javascript/gmaps.js
@@ -23,9 +23,9 @@ function addInfo(marker, header, info){
 	var markerInfo = '<table>';
 
 	for(var n = 0; n < info.length; n += 1){
-		name = header[n].replace(/\[.*\]/, '');
-		unit = header[n].replace(/[^\[]*\[?/, ' ').replace(/\]/g, '');
-		value = info[n].replace('Z[Etc/UTC]', ' UTC');
+		const name = header[n].replace(/\[.*\]/, '');
+		const unit = header[n].replace(/[^\[]*\[?/, ' ').replace(/\]/g, '');
+		const value = info[n].replace('Z[Etc/UTC]', ' UTC');
 		markerInfo += '<tr><td>' + name + ':</td><td>' + value + unit + '</td></tr>';
 	}
 	markerInfo += '</table>';

--- a/src/main/html/javascript/gmaps.js
+++ b/src/main/html/javascript/gmaps.js
@@ -24,7 +24,7 @@ function addInfo(marker, header, info){
 
 	for(var n = 0; n < info.length; n += 1){
 		name = header[n].replace(/\[.*\]/, '');
-		unit = header[n].replace(/[^\[]*\[?/, ' ').replace(']', '');
+		unit = header[n].replace(/[^\[]*\[?/, ' ').replace(/\]/g, '');
 		value = info[n].replace('Z[Etc/UTC]', ' UTC');
 		markerInfo += '<tr><td>' + name + ':</td><td>' + value + unit + '</td></tr>';
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/Samea-Innovation/D2CBridge/security/code-scanning/1](https://github.com/Samea-Innovation/D2CBridge/security/code-scanning/1)

Use a global regular expression so all `]` characters are removed, not just the first one.

Best minimal fix (without changing intended behavior): in `src/main/html/javascript/gmaps.js`, line 27 region, change:
- from: `...replace(']', '')`
- to: `...replace(/\]/g, '')`

This keeps the existing logic intact while ensuring complete replacement for all occurrences.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
