### PR TITLE
Potential fix for code scanning alert no. 6: User-controlled data in numeric cast

### DIFF
--- a/src/main/java/com/nestwave/device/service/NavigationService.java
+++ b/src/main/java/com/nestwave/device/service/NavigationService.java
@@ -346,10 +346,17 @@ public class NavigationService extends GnssService{
 		}
 
 		if (navResults.payload == null) {
-			log.info("downlink payload: {} | accuracy: {} | pos: {}", navResults.utcTime, (int) navResults.confidence, navResults.position);
+			int safeConfidence;
+			if (navResults.confidence < Integer.MIN_VALUE || navResults.confidence > Integer.MAX_VALUE) {
+				log.warn("Confidence value out of int range ({}), using fallback 65535", navResults.confidence);
+				safeConfidence = 65535;
+			} else {
+				safeConfidence = (int) navResults.confidence;
+			}
+			log.info("downlink payload: {} | accuracy: {} | pos: {}", navResults.utcTime, safeConfidence, navResults.position);
 			navResults.payload = ThintrackDownLinkEncoder.encode(
 					navResults.utcTime,
-                    (int) navResults.confidence,
+                    safeConfidence,
 					navResults.position
 			);
 			System.out.println(Arrays.toString(navResults.payload));;


### PR DESCRIPTION
Potential fix for [https://github.com/Samea-Innovation/D2CBridge/security/code-scanning/6](https://github.com/Samea-Innovation/D2CBridge/security/code-scanning/6)

To fix this safely without changing core behavior, validate `navResults.confidence` immediately before narrowing/use in downlink payload generation, and only pass a bounded `int` value to both logging and `ThintrackDownLinkEncoder.encode(...)`.

Best practical fix in `src/main/java/com/nestwave/device/service/NavigationService.java`:
- In the `if (navResults.payload == null)` block (around lines 348–353), introduce a local sanitized `int` variable derived from `navResults.confidence`.
- Guard against out-of-range values (`< Integer.MIN_VALUE` / `> Integer.MAX_VALUE`) and fallback to a safe default (`65535`, already used in this class for unknown confidence), with a warning log.
- Replace direct casts in log and encoder call with the sanitized variable.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
