### PR TITLE
Potential fix for code scanning alert no. 4: User-controlled data in numeric cast

### DIFF
--- a/src/main/java/com/traxmate/util/TraxmateSubmitDataMapper.java
+++ b/src/main/java/com/traxmate/util/TraxmateSubmitDataMapper.java
@@ -12,6 +12,18 @@ import org.springframework.stereotype.Component;
 public class TraxmateSubmitDataMapper {
     private final static int THINTRACK_TYPE_ID = 35976;
 
+    private int toSafeAccuracy(float confidence) {
+        if (!Float.isFinite(confidence)) {
+            return 0;
+        }
+        if (confidence > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        if (confidence < Integer.MIN_VALUE) {
+            return Integer.MIN_VALUE;
+        }
+        return (int) confidence;
+    }
 
     public TraxmateCapture mapData(long deviceId, long imei, int customerId, GnssPositionResults gnssPositionResults) {
         String name = "Thintrack - " + deviceId;
@@ -51,7 +63,7 @@ public class TraxmateSubmitDataMapper {
 
         signals.setPositioning(gnssPositionResults.technology);
 
-        signals.setAccuracy((int) gnssPositionResults.confidence);
+        signals.setAccuracy(toSafeAccuracy(gnssPositionResults.confidence));
         signals.setAltitude(gnssPositionResults.position[2]);
         signals.setHat(gnssPositionResults.HeightAboveTerrain);
         signals.setLocation(new Location(


### PR DESCRIPTION
Potential fix for [https://github.com/Samea-Innovation/D2CBridge/security/code-scanning/4](https://github.com/Samea-Innovation/D2CBridge/security/code-scanning/4)

Use a guarded conversion before setting Traxmate accuracy: validate/clamp `gnssPositionResults.confidence` to a safe `int` range and handle non-finite floats. This preserves functionality (still sends an integer accuracy) while preventing truncation surprises from malformed/extreme upstream values.

Best single fix in `src/main/java/com/traxmate/util/TraxmateSubmitDataMapper.java`:
- Add a private helper method in the class (for example `toSafeAccuracy(float confidence)`).
- In that method:
  - if `confidence` is `NaN` or infinite, return `0` (safe fallback).
  - if above `Integer.MAX_VALUE`, return `Integer.MAX_VALUE`.
  - if below `Integer.MIN_VALUE`, return `Integer.MIN_VALUE`.
  - otherwise cast to `int`.
- Replace line 54 cast with call to the helper.
- No new imports are needed (`Float.isFinite` can be used directly).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
