### PR TITLE
Potential fix for code scanning alert no. 2: `TrustManager` that accepts all certificates

### DIFF
--- a/src/main/java/com/nestwave/device/security/RestTemplateConfig.java
+++ b/src/main/java/com/nestwave/device/security/RestTemplateConfig.java
@@ -18,7 +18,6 @@
  *****************************************************************************/
 package com.nestwave.device.security;
 
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.springframework.boot.web.client.RestTemplateBuilder;
@@ -27,33 +26,11 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.X509Certificate;
-
-@Configuration // TODO: Comment this line to enable X509 certificate checking. Unless using a test navigation server (like localhost) you wont uncomment this line.
+@Configuration
 public class RestTemplateConfig{
 	@Bean
-	public RestTemplate restTemplate(RestTemplateBuilder builder) throws NoSuchAlgorithmException, KeyManagementException{
-		TrustManager[] trustAllCerts = new TrustManager[] {
-				new X509TrustManager() {
-					public java.security.cert.X509Certificate[] getAcceptedIssuers() {
-						return new X509Certificate[0];
-					}
-					public void checkClientTrusted(java.security.cert.X509Certificate[] certs, String authType){
-					}
-					public void checkServerTrusted(java.security.cert.X509Certificate[] certs, String authType){
-					}
-				}
-		};
-		SSLContext sslContext = SSLContext.getInstance("SSL");
-		sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
+	public RestTemplate restTemplate(RestTemplateBuilder builder){
 		CloseableHttpClient httpClient = HttpClients.custom()
-				.setSSLContext(sslContext)
-				.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
 				.build();
 		HttpComponentsClientHttpRequestFactory customRequestFactory = new HttpComponentsClientHttpRequestFactory();
 		customRequestFactory.setHttpClient(httpClient);


### PR DESCRIPTION
Potential fix for [https://github.com/Samea-Innovation/D2CBridge/security/code-scanning/2](https://github.com/Samea-Innovation/D2CBridge/security/code-scanning/2)

Use the platform/default TLS trust configuration instead of a custom “trust-all” manager.

Best fix in this file: remove the custom `TrustManager[] trustAllCerts`, remove manual `SSLContext` initialization, and remove `NoopHostnameVerifier`. Build the `CloseableHttpClient` with defaults so Java/Spring/Apache HTTP client performs normal certificate chain and hostname validation. This preserves functionality (a `RestTemplate` bean still exists) while restoring TLS security.

Edits needed in `src/main/java/com/nestwave/device/security/RestTemplateConfig.java`:
- Remove insecure imports (`NoopHostnameVerifier`, `SSLContext`, `TrustManager`, `X509TrustManager`, `X509Certificate`, and related thrown exceptions no longer needed).
- Simplify `restTemplate(...)` signature to remove `throws NoSuchAlgorithmException, KeyManagementException`.
- Replace insecure client construction block with default `HttpClients.custom().build()` and keep request factory wiring unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
